### PR TITLE
Wrap long lines for plain CWEB (4.6 and 3.64c).

### DIFF
--- a/web2w/0001-Wrap-long-lines-for-plain-CWEB-4.6-3.64c.patch
+++ b/web2w/0001-Wrap-long-lines-for-plain-CWEB-4.6-3.64c.patch
@@ -1,0 +1,65 @@
+From 0f4716f461b79702f3d4bfdf9d0450f78562d93f Mon Sep 17 00:00:00 2001
+From: Andreas Scherer <andreas_github@freenet.de>
+Date: Wed, 12 Jan 2022 09:49:41 +0100
+Subject: [PATCH] Wrap long lines for plain CWEB (4.6, 3.64c).
+
+---
+ cdvitype.w | 34 +++++++++++++++++++++++-----------
+ 1 file changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/cdvitype.w b/cdvitype.w
+index 7071e89..085672d 100644
+--- a/cdvitype.w
++++ b/cdvitype.w
+@@ -1726,9 +1726,12 @@ called |hstack|, \dots, |zstack|, |hhstack|, and |vvstack|.
+ @<Glob...@>=
+ int @!h, @!v, @!w, @!x, @!y, @!z, @!hh, @!vv; /*current state values*/ 
+ 
+-  int @!hstack[stack_size+1], @!vstack[stack_size+1], @!wstack[stack_size+1], @!xstack[stack_size+1], @!ystack[stack_size+1], @!zstack[stack_size+1]; /*pushed down values in \.{DVI} units*/ 
++  int @!hstack[stack_size+1], @!vstack[stack_size+1], @!wstack[stack_size+1],
++    @!xstack[stack_size+1], @!ystack[stack_size+1], @!zstack[stack_size+1];
++    /*pushed down values in \.{DVI} units*/ 
+ 
+-  int @!hhstack[stack_size+1], @!vvstack[stack_size+1]; /*pushed down values in pixels*/ 
++  int @!hhstack[stack_size+1], @!vvstack[stack_size+1];
++    /*pushed down values in pixels*/ 
+ 
+ @ Three characteristics of the pages (their |max_v|, |max_h|, and
+ |max_s|) are specified in the postamble, and a warning message
+@@ -1767,15 +1770,24 @@ opcode.
+ {@+switch (o) {
+ sixty_four_cases(set_char_0): sixty_four_cases(set_char_0+64): 
+   return o-set_char_0;@+break;
+-case set1: case put1: case fnt1: case xxx1: case fnt_def1: return get_byte();@+break;
+-case set1+1: case put1+1: case fnt1+1: case xxx1+1: case fnt_def1+1: return get_two_bytes();@+break;
+-case set1+2: case put1+2: case fnt1+2: case xxx1+2: case fnt_def1+2: return get_three_bytes();@+break;
+-case right1: case w1: case x1: case down1: case y1: case z1: return signed_byte();@+break;
+-case right1+1: case w1+1: case x1+1: case down1+1: case y1+1: case z1+1: return signed_pair();@+break;
+-case right1+2: case w1+2: case x1+2: case down1+2: case y1+2: case z1+2: return signed_trio();@+break;
+-case set1+3: case set_rule: case put1+3: case put_rule: case right1+3: case w1+3: case x1+3: case down1+3: case y1+3: case z1+3: 
+-  case fnt1+3: case xxx1+3: case fnt_def1+3: return signed_quad();@+break;
+-case nop: case bop: case eop: case push: case pop: case pre: case post: case post_post: undefined_commands: return 0;@+break;
++case set1: case put1: case fnt1: case xxx1: case fnt_def1:
++  return get_byte();@+break;
++case set1+1: case put1+1: case fnt1+1: case xxx1+1: case fnt_def1+1:
++  return get_two_bytes();@+break;
++case set1+2: case put1+2: case fnt1+2: case xxx1+2: case fnt_def1+2:
++  return get_three_bytes();@+break;
++case right1: case w1: case x1: case down1: case y1: case z1:
++  return signed_byte();@+break;
++case right1+1: case w1+1: case x1+1: case down1+1: case y1+1: case z1+1:
++  return signed_pair();@+break;
++case right1+2: case w1+2: case x1+2: case down1+2: case y1+2: case z1+2:
++  return signed_trio();@+break;
++case set1+3: case set_rule: case put1+3: case put_rule: case right1+3:
++  case w1+3: case x1+3: case down1+3: case y1+3: case z1+3: 
++  case fnt1+3: case xxx1+3: case fnt_def1+3:
++  return signed_quad();@+break;
++case nop: case bop: case eop: case push: case pop: case pre: case post:
++  case post_post: undefined_commands: return 0;@+break;
+ case w0: return w;@+break;
+ case x0: return x;@+break;
+ case y0: return y;@+break;
+-- 
+2.34.1
+

--- a/web2w/Makefile
+++ b/web2w/Makefile
@@ -10,3 +10,4 @@ all:
 	@sed -i '821s/file/File/;1752,1756s/+/,/g' dvitype-web2w.web
 	./web2w -o cdvitype.w dvitype-web2w.web
 	patch cdvitype.w cdvitype.patch
+	patch cdvitype.w 0001-Wrap-long-lines-for-plain-CWEB-4.6-3.64c.patch


### PR DESCRIPTION
I've notified Martin Ruckert to amend `web2w` accordingly, but for the time being a manually created patch should suffice.