### PR TITLE
Use non-local 'ctangle'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
 	make -C web2w
 	cp web2w/cdvitype.w dvitype.w
-	/bin/ctangle dvitype
+	ctangle dvitype
 	gcc dvitype.c -o dvitype -lm

--- a/web2w/Makefile
+++ b/web2w/Makefile
@@ -1,6 +1,6 @@
 all:
 	tie -c web2w.ch web2w.w web2w-dvitype.ch web2w-stringpool.ch
-	/bin/ctangle web2w web2w
+	ctangle web2w web2w
 	patch -o web-dvitype.l web.l web-dvitype.patch
 	flex -o web.lex.c web-dvitype.l
 	patch -o pascal-dvitype.y pascal.y pascal-dvitype.patch


### PR DESCRIPTION
After the recent patch, any `ctangle` should grok `dvitype.w`. Best to use **CWEB 4.6**.