### PR TITLE
Create 'original' dvitype.pdf.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ all:
 	cp web2w/cdvitype.w dvitype.w
 	ctangle dvitype
 	gcc dvitype.c -o dvitype -lm
-	cweave dvitype && pdftex dvitype
+	cweave -f dvitype && pdftex dvitype

--- a/web2w/.gitignore
+++ b/web2w/.gitignore
@@ -10,3 +10,4 @@ web2w
 web2w.c
 web2w.h
 cdvitype.w
+CONTENTS.tex

--- a/web2w/Makefile
+++ b/web2w/Makefile
@@ -11,3 +11,6 @@ all:
 	./web2w -o cdvitype.w dvitype-web2w.web
 	patch cdvitype.w cdvitype.patch
 	patch cdvitype.w 0001-Wrap-long-lines-for-plain-CWEB-4.6-3.64c.patch
+	weave dvitype && \
+		sed -i '1s/input webmac/input pwebmac/' dvitype.tex && \
+		pdftex dvitype


### PR DESCRIPTION
Now we can compare the original WEB dvitype (in 'web2w') with the modified CWEB dvitype (in top dir) directly.